### PR TITLE
Add Python 3.14 to classifiers and testing matrix

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -51,6 +51,8 @@ jobs:
                       django-version: "5.2"
                     - python-version: "3.13"
                       django-version: "5.2"
+                    - python-version: "3.14"
+                      django-version: "5.2"
 
         steps:
             - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Internet :: WWW/HTTP",
     "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
     "Topic :: Internet :: WWW/HTTP :: WSGI",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended Python version support to include Python 3.14 and updated testing matrix to verify compatibility with Python 3.14 and Django 5.2.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->