### PR TITLE
feat: allow Entra server env override

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,6 @@ INSTALLED_APPS = (
 # Basic configuration for Entra ID
 # checkout the documentation for more settings
 ENTRA_AUTH = {
-    # For Entra ID, use 'login.microsoftonline.com/<your-tenant-id>'
-    "SERVER": "login.microsoftonline.com/<your-tenant-id>",
     "CLIENT_ID": "your-application-client-id",
     "RELYING_PARTY_ID": "your-application-client-id", # Often same as CLIENT_ID for Entra ID
     # OIDC Audience ("aud" claim). For Entra ID, LIENT_ID
@@ -68,6 +66,9 @@ ENTRA_AUTH = {
     # "TOKEN_REFRESH_THRESHOLD", "STORE_OBO_TOKEN", "TOKEN_ENCRYPTION_SALT",
     # "LOGOUT_ON_TOKEN_REFRESH_FAILURE"
 }
+
+# Optional: override the Entra ID server host for development/testing.
+# For example: ENTRA_AUTH_SERVER=mock-server.example.com
 
 # Configure django to redirect users to the right URL for login
 LOGIN_URL = "django_entra_auth:login"

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ INSTALLED_APPS = (
 # Basic configuration for Entra ID
 # checkout the documentation for more settings
 ENTRA_AUTH = {
+    # For Entra ID, use 'login.microsoftonline.com/<your-tenant-id>'
+    "SERVER": "login.microsoftonline.com/<your-tenant-id>",
     "CLIENT_ID": "your-application-client-id",
     "RELYING_PARTY_ID": "your-application-client-id", # Often same as CLIENT_ID for Entra ID
     # OIDC Audience ("aud" claim). For Entra ID, LIENT_ID

--- a/django_entra_auth/config.py
+++ b/django_entra_auth/config.py
@@ -1,5 +1,6 @@
 import base64
 import logging
+import os
 import warnings
 from datetime import datetime, timedelta
 
@@ -24,6 +25,7 @@ except ImportError:  # Django < 1.10
 logger = logging.getLogger("django_entra_auth")
 
 AZURE_AD_SERVER = "login.microsoftonline.com"
+SERVER_ENVIRONMENT_VARIABLE = "ENTRA_AUTH_SERVER"
 DEFAULT_SETTINGS_CLASS = "django_entra_auth.config.Settings"
 
 
@@ -65,7 +67,7 @@ class Settings(object):
         self.MIRROR_GROUPS = False
         self.RELYING_PARTY_ID = None  # Required
         self.RETRIES = 3
-        self.SERVER = AZURE_AD_SERVER
+        self.SERVER = os.environ.get(SERVER_ENVIRONMENT_VARIABLE, AZURE_AD_SERVER)
         self.TENANT_ID = None  # Required
         self.TIMEOUT = 5
         self.USERNAME_CLAIM = "upn"

--- a/docs/settings_ref.rst
+++ b/docs/settings_ref.rst
@@ -346,6 +346,19 @@ must be callable with no arguments to initialize.
 Use cases are storing configuration in database so an administrator can edit
 the configuration in an admin interface.
 
+ENTRA_AUTH_SERVER environment variable
+--------------------------------------
+* **Default**: ``login.microsoftonline.com``
+* **Type**: ``string``
+
+By default, django-entra-auth uses ``login.microsoftonline.com`` as the Entra ID server.
+Set the ``ENTRA_AUTH_SERVER`` environment variable to override this host, for example when
+pointing development or test environments at a mock OpenID Connect server.
+
+.. code-block:: shell
+
+    ENTRA_AUTH_SERVER=mock-server.example.com
+
 .. _tenant_id_setting:
 
 TENANT_ID

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,3 +1,4 @@
+import os
 import sys
 from copy import deepcopy
 
@@ -33,6 +34,11 @@ class SettingsTests(TestCase):
             # This should now show a deprecation warning instead of raising ImproperlyConfigured
             config = Settings()
             self.assertEqual(config.SERVER, "login.microsoftonline.com")
+
+    def test_server_can_be_overridden_with_environment_variable(self):
+        with patch.dict(os.environ, {"ENTRA_AUTH_SERVER": "mock-server.example.com"}):
+            config = Settings()
+            self.assertEqual(config.SERVER, "mock-server.example.com")
 
     def test_no_tenant_id(self):
         settings = deepcopy(django_settings)


### PR DESCRIPTION
## Summary
- Add ENTRA_AUTH_SERVER environment variable to override the default login.microsoftonline.com host
- Keep the existing default behavior when the variable is unset
- Document the override

## Test plan
- uv run python manage.py test tests.test_settings -v 2
- uv run ruff check .
- uv run python manage.py test -v 2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for overriding the Entra ID server host with a dedicated environment variable for development and testing.
  * Updated the configuration reference to document the new optional server override and its default behavior.

* **Bug Fixes**
  * Improved configuration handling so the server host now falls back to the standard default when no override is set.

* **Tests**
  * Added coverage to confirm the server host can be changed via environment variable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->