### PR TITLE
[codex] allow ENTRA_AUTH server override

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,11 +53,13 @@ INSTALLED_APPS = (
 # Basic configuration for Entra ID
 # checkout the documentation for more settings
 ENTRA_AUTH = {
-    # For Entra ID, use 'login.microsoftonline.com/<your-tenant-id>'
-    "SERVER": "login.microsoftonline.com/<your-tenant-id>",
+    # Optional. Defaults to "login.microsoftonline.com".
+    # Override for national clouds or compatible Entra ID hosts.
+    "SERVER": "login.microsoftonline.com",
+    "TENANT_ID": "your-tenant-id",
     "CLIENT_ID": "your-application-client-id",
     "RELYING_PARTY_ID": "your-application-client-id", # Often same as CLIENT_ID for Entra ID
-    # OIDC Audience ("aud" claim). For Entra ID, LIENT_ID
+    # OIDC Audience ("aud" claim). For Entra ID, CLIENT_ID
     "AUDIENCE": "your-application-client-id",
     # Set to False for Entra ID. Provide path for ADFS.
     "CA_BUNDLE": False,

--- a/django_entra_auth/config.py
+++ b/django_entra_auth/config.py
@@ -146,13 +146,6 @@ class Settings(object):
             _settings["RELYING_PARTY_ID"] = _settings["RESOURCE"]
             del _settings["RESOURCE"]
 
-        if "SERVER" in _settings:
-            warnings.warn(
-                "Setting SERVER is not required and will be ignored. Entra ID server will be used.",
-                DeprecationWarning,
-            )
-            del _settings["SERVER"]
-
         if self.VERSION == "v2.0" and not self.SCOPES and self.RELYING_PARTY_ID:
             warnings.warn(
                 "Use `SCOPES` for AzureAD instead of RELYING_PARTY_ID",

--- a/docs/settings_ref.rst
+++ b/docs/settings_ref.rst
@@ -346,6 +346,26 @@ must be callable with no arguments to initialize.
 Use cases are storing configuration in database so an administrator can edit
 the configuration in an admin interface.
 
+SERVER
+------
+* **Default**: ``login.microsoftonline.com``
+* **Type**: ``string``
+
+The Entra ID host used to load OpenID Connect configuration.
+
+Override this when using a national cloud or another compatible Entra ID host.
+Do not include the URL scheme or tenant ID; ``TENANT_ID`` is configured separately
+and is added to the discovery URL by django-entra-auth.
+
+Example:
+
+.. code-block:: python
+
+    ENTRA_AUTH = {
+        "SERVER": "login.microsoftonline.us",
+        "TENANT_ID": "your-tenant-id",
+    }
+
 .. _tenant_id_setting:
 
 TENANT_ID

--- a/tests/test_drf_integration.py
+++ b/tests/test_drf_integration.py
@@ -76,7 +76,6 @@ class RestFrameworkIntegrationTests(TestCase):
         from django_entra_auth.config import django_settings
 
         settings = deepcopy(django_settings)
-        # SERVER is no longer needed as it's now fixed to login.microsoftonline.com
         settings.ENTRA_AUTH["TENANT_ID"] = "dummy_tenant_id"
         with patch("django_entra_auth.config.django_settings", settings):
             with patch("django_entra_auth.config.settings", Settings()):
@@ -94,7 +93,6 @@ class RestFrameworkIntegrationTests(TestCase):
         from django_entra_auth.config import django_settings
 
         settings = deepcopy(django_settings)
-        # SERVER is no longer needed as it's now fixed to login.microsoftonline.com
         settings.ENTRA_AUTH["TENANT_ID"] = "dummy_tenant_id"
         settings.ENTRA_AUTH["BLOCK_GUEST_USERS"] = True
         with patch("django_entra_auth.config.django_settings", settings):
@@ -114,7 +112,6 @@ class RestFrameworkIntegrationTests(TestCase):
         from django_entra_auth.config import django_settings
 
         settings = deepcopy(django_settings)
-        # SERVER is no longer needed as it's now fixed to login.microsoftonline.com
         settings.ENTRA_AUTH["TENANT_ID"] = "dummy_tenant_id"
         settings.ENTRA_AUTH["BLOCK_GUEST_USERS"] = True
         with patch("django_entra_auth.config.django_settings", settings):
@@ -133,7 +130,6 @@ class RestFrameworkIntegrationTests(TestCase):
         from django_entra_auth.config import django_settings
 
         settings = deepcopy(django_settings)
-        # SERVER is no longer needed as it's now fixed to login.microsoftonline.com
         settings.ENTRA_AUTH["TENANT_ID"] = "dummy_tenant_id"
         settings.ENTRA_AUTH["GUEST_USERNAME_CLAIM"] = "email"
         settings.ENTRA_AUTH["BLOCK_GUEST_USERS"] = False
@@ -153,7 +149,6 @@ class RestFrameworkIntegrationTests(TestCase):
         from django_entra_auth.config import django_settings
 
         settings = deepcopy(django_settings)
-        # SERVER is no longer needed as it's now fixed to login.microsoftonline.com
         settings.ENTRA_AUTH["TENANT_ID"] = "dummy_tenant_id"
         settings.ENTRA_AUTH["GUEST_USERNAME_CLAIM"] = "email"
         settings.ENTRA_AUTH["BLOCK_GUEST_USERS"] = False
@@ -173,7 +168,6 @@ class RestFrameworkIntegrationTests(TestCase):
         from django_entra_auth.config import django_settings
 
         settings = deepcopy(django_settings)
-        # SERVER is no longer needed as it's now fixed to login.microsoftonline.com
         settings.ENTRA_AUTH["TENANT_ID"] = "dummy_tenant_id"
         settings.ENTRA_AUTH["GUEST_USERNAME_CLAIM"] = (
             None  # <--- Set to None, should not be validated as OK
@@ -198,7 +192,6 @@ class RestFrameworkIntegrationTests(TestCase):
         from django_entra_auth.config import django_settings
 
         settings = deepcopy(django_settings)
-        # SERVER is no longer needed as it's now fixed to login.microsoftonline.com
         settings.ENTRA_AUTH["TENANT_ID"] = "dummy_tenant_id"
         with patch("django_entra_auth.config.django_settings", settings):
             with patch("django_entra_auth.backend.settings", Settings()):
@@ -221,7 +214,6 @@ class RestFrameworkIntegrationTests(TestCase):
         from django_entra_auth.config import django_settings
 
         settings = deepcopy(django_settings)
-        # SERVER is no longer needed as it's now fixed to login.microsoftonline.com
         settings.ENTRA_AUTH["TENANT_ID"] = "dummy_tenant_id"
         with patch("django_entra_auth.config.django_settings", settings):
             with patch("django_entra_auth.backend.settings", Settings()):
@@ -242,7 +234,6 @@ class RestFrameworkIntegrationTests(TestCase):
         from django_entra_auth.config import django_settings
 
         settings = deepcopy(django_settings)
-        # SERVER is no longer needed as it's now fixed to login.microsoftonline.com
         settings.ENTRA_AUTH["TENANT_ID"] = "dummy_tenant_id"
         settings.ENTRA_AUTH["VERSION"] = "v2.0"
         with patch("django_entra_auth.config.django_settings", settings):
@@ -266,7 +257,6 @@ class RestFrameworkIntegrationTests(TestCase):
         from django_entra_auth.config import django_settings
 
         settings = deepcopy(django_settings)
-        # SERVER is no longer needed as it's now fixed to login.microsoftonline.com
         settings.ENTRA_AUTH["TENANT_ID"] = "dummy_tenant_id"
         with patch("django_entra_auth.config.django_settings", settings):
             with patch("django_entra_auth.backend.settings", Settings()):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -3,8 +3,10 @@ from copy import deepcopy
 
 from django.core.exceptions import ImproperlyConfigured
 from django.test import TestCase, SimpleTestCase, override_settings
-from mock import patch
+from mock import Mock, patch
+from requests import HTTPError
 from django_entra_auth.config import django_settings
+from django_entra_auth.config import ConfigLoadError
 from django_entra_auth.config import Settings
 from django_entra_auth.config import ProviderConfig
 from .custom_config import Settings as CustomSettings
@@ -30,9 +32,8 @@ class SettingsTests(TestCase):
         settings.ENTRA_AUTH["TENANT_ID"] = "abc"
         settings.ENTRA_AUTH["SERVER"] = "abc"
         with patch("django_entra_auth.config.django_settings", settings):
-            # This should now show a deprecation warning instead of raising ImproperlyConfigured
             config = Settings()
-            self.assertEqual(config.SERVER, "login.microsoftonline.com")
+            self.assertEqual(config.SERVER, "abc")
 
     def test_no_tenant_id(self):
         settings = deepcopy(django_settings)
@@ -48,7 +49,6 @@ class SettingsTests(TestCase):
 
     def test_tenant_with_block_users(self):
         settings = deepcopy(django_settings)
-        # SERVER is no longer needed as it's now fixed to login.microsoftonline.com
         settings.ENTRA_AUTH["TENANT_ID"] = "abc"
         settings.ENTRA_AUTH["BLOCK_GUEST_USERS"] = True
         with patch("django_entra_auth.config.django_settings", settings):
@@ -88,7 +88,6 @@ class SettingsTests(TestCase):
         settings = deepcopy(django_settings)
         current_settings = Settings()
         self.assertEqual(current_settings.VERSION, "v1.0")
-        # SERVER is no longer needed as it's now fixed to login.microsoftonline.com
         settings.ENTRA_AUTH["TENANT_ID"] = "abc"
         settings.ENTRA_AUTH["VERSION"] = "v2.0"
         with patch("django_entra_auth.config.django_settings", settings):
@@ -96,14 +95,33 @@ class SettingsTests(TestCase):
             self.assertEqual(current_settings.VERSION, "v2.0")
 
     def test_version_setting(self):
-        # Renamed from test_not_azure_but_version_is_set since
-        # that test is no longer valid - SERVER is always Azure AD now
         settings = deepcopy(django_settings)
         settings.ENTRA_AUTH["TENANT_ID"] = "abc"
         settings.ENTRA_AUTH["VERSION"] = "v2.0"
         with patch("django_entra_auth.config.django_settings", settings):
             config = Settings()
             self.assertEqual(config.VERSION, "v2.0")
+
+    def test_openid_config_uses_configured_server(self):
+        settings = Settings()
+        settings.CLIENT_ID = "client"
+        settings.SERVER = "login.microsoftonline.us"
+        settings.TENANT_ID = "tenant"
+
+        with patch("django_entra_auth.config.settings", settings):
+            provider_config = ProviderConfig()
+
+            response = Mock()
+            response.raise_for_status.side_effect = HTTPError()
+            provider_config.session.get = Mock(return_value=response)
+
+            with self.assertRaises(ConfigLoadError):
+                provider_config._load_openid_config()
+
+            provider_config.session.get.assert_called_once_with(
+                "https://login.microsoftonline.us/tenant/.well-known/openid-configuration?appid=client",
+                timeout=settings.TIMEOUT,
+            )
 
     def test_configured_proxy(self):
         settings = Settings()


### PR DESCRIPTION
## Summary

Allows ENTRA_AUTH["SERVER"] to override the default Entra ID authority host instead of being warned away and deleted during settings initialization.

## Root Cause

Settings.__init__ set a default SERVER, but then treated any user-provided SERVER value as deprecated, emitted a warning, and removed it before applying user settings. That made the setting appear configurable while always forcing login.microsoftonline.com.

## Impact

Projects can now configure alternate compatible Entra ID hosts, such as national cloud authorities, while keeping TENANT_ID as the separate tenant path segment. The README and settings reference now document that contract.

## Validation

- uv run python manage.py test
- uv run ruff check .

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified Entra ID setup examples and settings reference, including how to configure the base server host and tenant separately.
  * Updated the audience example and improved readability in the contributing guide.

* **Bug Fixes**
  * Improved handling of legacy Entra settings so existing configurations are mapped more reliably.
  * OpenID configuration loading now uses the configured server and tenant values, with clearer error handling when the remote configuration cannot be loaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->